### PR TITLE
Use pre-commit to run code checks (also in CI)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 ignore = E731, T484, T400 # Do not assign a lambda expression, use a def
-max-line-length = 120
+max-line-length = 121

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,14 +25,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Lint with flake8
+      - name: Code checks
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          pre-commit run --all-files --show-diff-on-failure
       - name: Test with pytest
         run: |
           pytest --cov --cov-report xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  python: python3.8
 exclude: "_version.py|versioneer.py"
 repos:
 - hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+default_language_version:
+  python: python3.8
+exclude: "_version.py|versioneer.py"
+repos:
+- hooks:
+    - args:
+        - --remove-all-unused-imports
+        - --in-place
+      id: autoflake
+  repo: https://github.com/humitos/mirrors-autoflake
+  rev: v1.1
+- hooks:
+    - id: isort
+  repo: https://github.com/timothycrosley/isort
+  rev: 5.6.4
+- hooks:
+    - id: black
+  repo: https://github.com/psf/black
+  rev: 20.8b1
+- hooks:
+    - id: flake8
+  repo: https://gitlab.com/pycqa/flake8
+  rev: 3.8.4

--- a/README.md
+++ b/README.md
@@ -560,8 +560,17 @@ nice if you can try to align the code and naming with F# modules, functions,
 and documentation if possible. But submit a PR even if you should feel unsure.
 
 Code, doc-strings, and comments should also follow the [Google Python Style
-Guide](https://google.github.io/styleguide/pyguide.html). Code is formatted
-using [Black](https://github.com/psf/black).
+Guide](https://google.github.io/styleguide/pyguide.html). 
+
+Code checks are done using
+- [Black](https://github.com/psf/black)
+- [flake8](https://github.com/PyCQA/flake8)
+- [isort](https://github.com/PyCQA/isort)
+
+To run code checks on changed files every time you commit, install the pre-commit hooks by running:
+```
+pre-commit install
+```
 
 ## Code of Conduct
 

--- a/expression/__init__.py
+++ b/expression/__init__.py
@@ -9,10 +9,10 @@ GitHub: https://github.com/dbrattli/Expression
 """
 
 from . import collections, core, effect
+from ._version import get_versions
 
 __all__ = ["core", "collections", "effect"]
 
-from ._version import get_versions
 
 __version__ = get_versions()["version"]  # type: ignore
 del get_versions

--- a/expression/collections/map.py
+++ b/expression/collections/map.py
@@ -576,31 +576,6 @@ def try_find(key: Key) -> Callable[[Map[Key, Value]], Option[Value]]:
 
 empty: Map[Any, Any] = Map.empty()
 
-# let groupBy (projection: 'T -> 'Key) (xs: 'T seq) ([<Fable.Core.Inject>] comparer: IEqualityComparer<'Key>): ('Key * 'T seq) seq =
-#     let dict: Fable.Core.JS.Map<_,ResizeArray<'T>> = createMutable Seq.empty comparer
-
-#     // Build the groupings
-#     for v in xs do
-#         let key = projection v
-#         if dict.has(key) then dict.get(key).Add(v)
-#         else dict.set(key, ResizeArray [v]) |> ignore
-
-#     // Mapping shouldn't be necessary because KeyValuePair compiles
-#     // as a tuple, but let's do it just in case the implementation changes
-#     dict.entries() |> Seq.map (fun (k,v) -> k, upcast v)
-
-# let countBy (projection: 'T -> 'Key) (xs: 'T seq) ([<Fable.Core.Inject>] comparer: IEqualityComparer<'Key>): ('Key * int) seq =
-#     let dict = createMutable Seq.empty comparer
-
-#     for value in xs do
-#         let key = projection value
-#         if dict.has(key) then dict.set(key, dict.get(key) + 1)
-#         else dict.set(key, 1)
-#         |> ignore
-
-#     dict.entries()
-
-
 __all__ = [
     "Map",
     "add",

--- a/expression/collections/maptree.py
+++ b/expression/collections/maptree.py
@@ -24,11 +24,9 @@ Do not use directly. Use the `map` module instead.
 """
 import builtins
 from dataclasses import dataclass
-from typing import (Any, Callable, Generic, Iterable, Iterator, Tuple, TypeVar,
-                    cast)
+from typing import Any, Callable, Generic, Iterable, Iterator, Tuple, TypeVar, cast
 
-from expression.core import (Nothing, Option, Some, SupportsLessThan, failwith,
-                             pipe)
+from expression.core import Nothing, Option, Some, SupportsLessThan, failwith, pipe
 
 from . import frozenlist, seq
 from .frozenlist import FrozenList

--- a/expression/core/aiotools.py
+++ b/expression/core/aiotools.py
@@ -96,7 +96,6 @@ async def sleep(msecs: int) -> None:
 
 async def empty() -> None:
     """Async no-op"""
-    pass
 
 
 def from_result(result: TSource) -> Awaitable[TSource]:

--- a/oryx/__init__.py
+++ b/oryx/__init__.py
@@ -1,5 +1,4 @@
 from . import context as Context
 from . import handler as Handler
 
-
 __all__ = ["Context", "Handler"]

--- a/oryx/context.py
+++ b/oryx/context.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, Generic, NamedTuple, Tuple, TypeVar
 
 from aiohttp import ClientResponse, ClientSession
+
 from expression.collections import Seq, seq
 from expression.core import Nothing, Option, failwith
 

--- a/oryx/examples/app.py
+++ b/oryx/examples/app.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import aiohttp
+
 from expression.core import pipe
 from oryx.context import default_context, with_http_session
 from oryx.fetch import fetch

--- a/oryx/fetch.py
+++ b/oryx/fetch.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable, TypeVar
 
 from aiohttp import ClientResponse
+
 from expression.core import Error, Option, Some, Try, option, pipe
 
 from .context import Context, HttpContent, HttpContext

--- a/oryx/handler.py
+++ b/oryx/handler.py
@@ -1,6 +1,7 @@
 from typing import Any, Awaitable, Callable, Dict, Protocol, TypeVar, cast
 
 from aiohttp import ClientResponse
+
 from expression.core import Nothing, Option, Success, Try, aiotools, compose, match, option
 
 from .context import Context, HttpContext, HttpMethod

--- a/oryx/pipeline.py
+++ b/oryx/pipeline.py
@@ -2,6 +2,7 @@ from functools import reduce
 from typing import Any, TypeVar, overload
 
 from aiohttp import ClientResponse
+
 from expression.core import Option
 
 from .context import Context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.black]
+line-length = 120
+target_version = ['py38']
+include = '\.py$'
+
+[tool.isort]
+line_length=120                # corresponds to -w  flag
+multi_line_output=3            # corresponds to -m  flag
+include_trailing_comma=true    # corresponds to -tc flag
+skip_glob = '^((?!py$).)*$'    # isort all Python files
+float_to_top=true

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+  "exclude": ["expression/_version.py"]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ hypothesis
 pytest
 pytest-cov
 pytest-asyncio
+pre-commit

--- a/tests/test_asyncseq.py
+++ b/tests/test_asyncseq.py
@@ -1,7 +1,8 @@
 import pytest
-from expression.collections.asyncseq import AsyncSeq
 from hypothesis import given
 from hypothesis import strategies as st
+
+from expression.collections.asyncseq import AsyncSeq
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -1,4 +1,5 @@
 import pytest
+
 from expression.system import CancellationToken, CancellationTokenSource, ObjectDisposedException
 
 

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,8 +1,9 @@
 from typing import Callable
 
-from expression.core import compose, identity
 from hypothesis import given
 from hypothesis import strategies as st
+
+from expression.core import compose, identity
 
 Func = Callable[[int], int]
 

--- a/tests/test_curried.py
+++ b/tests/test_curried.py
@@ -1,6 +1,7 @@
 from typing import Callable, overload
 
 import pytest
+
 from expression.core import curried
 
 

--- a/tests/test_disposable.py
+++ b/tests/test_disposable.py
@@ -1,4 +1,5 @@
 import pytest
+
 from expression.system import AsyncDisposable, Disposable, ObjectDisposedException
 
 

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -2,10 +2,11 @@ import functools
 from builtins import list as list
 from typing import Any, Callable, List, Tuple
 
-from expression.collections import FrozenList, frozenlist
-from expression.core import Nothing, Option, Some, pipe
 from hypothesis import given
 from hypothesis import strategies as st
+
+from expression.collections import FrozenList, frozenlist
+from expression.core import Nothing, Option, Some, pipe
 
 Func = Callable[[int], int]
 

--- a/tests/test_mailbox.py
+++ b/tests/test_mailbox.py
@@ -2,9 +2,10 @@ import asyncio
 from typing import Callable, List, Tuple
 
 import pytest
-from expression.core import AsyncReplyChannel, MailboxProcessor
 from hypothesis import given
 from hypothesis import strategies as st
+
+from expression.core import AsyncReplyChannel, MailboxProcessor
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -47,7 +47,7 @@ def test_map_to_seq(xs: Dict[str, int]):
     items: ItemsView[str, int] = xs.items()
     ys = map.of_seq(items)
     zs = pipe(ys, map.to_seq)
-    assert list(xs) == list(zs)
+    assert sorted(list(items)) == list(zs)
 
 
 @given(st.dictionaries(keys=st.text(), values=st.integers()))

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,9 +1,10 @@
 from typing import Callable, Dict, ItemsView, Iterable, Tuple
 
-from expression.collections import FrozenList, Map, map
-from expression.core import pipe
 from hypothesis import given
 from hypothesis import strategies as st
+
+from expression.collections import FrozenList, Map, map
+from expression.core import pipe
 
 
 def test_map_empty():
@@ -73,14 +74,6 @@ def test_map_remove(xs: Dict[str, int]):
         m = pipe(m, map.remove(key))
         count -= 1
     assert len(m) == count == 0
-
-
-@given(st.dictionaries(keys=st.text(), values=st.integers()))
-def test_map_to_seq(xs: Dict[str, int]):
-    items: ItemsView[str, int] = xs.items()
-    ys = map.of_seq(items).to_seq()
-
-    assert sorted(list(items)) == list(ys)
 
 
 @given(st.dictionaries(keys=st.text(), values=st.integers()))

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -1,12 +1,12 @@
 from typing import Any, Callable, Generator
 
 import pytest
-from expression import effect
-from expression.core import Nothing, Option, Some, match, option, pipe, pipe2
-from expression.extra.option import pipeline
 from hypothesis import given
 from hypothesis import strategies as st
 
+from expression import effect
+from expression.core import Nothing, Option, Some, match, option, pipe, pipe2
+from expression.extra.option import pipeline
 from tests.utils import CustomException
 
 

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -1,8 +1,9 @@
 from typing import Callable
 
-from expression.core import pipe, pipe2
 from hypothesis import given
 from hypothesis import strategies as st
+
+from expression.core import pipe, pipe2
 
 
 @given(st.integers())

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,11 +1,12 @@
 from typing import Callable, Generator, List, Optional
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
 from expression import effect
 from expression.core import Error, Ok, Result, match, result
 from expression.extra.result import pipeline, sequence
-from hypothesis import given
-from hypothesis import strategies as st
 
 from .utils import CustomException
 

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -3,11 +3,12 @@ from itertools import accumulate
 from typing import Callable, Generator, Iterable, List, Tuple
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
 from expression import effect
 from expression.collections import Seq, seq
 from expression.core import Nothing, Option, Some, option, pipe
-from hypothesis import given
-from hypothesis import strategies as st
 
 
 def test_seq_empty():

--- a/tests/test_try.py
+++ b/tests/test_try.py
@@ -1,9 +1,6 @@
-from typing import Callable, Generator, List, Optional
-
 import pytest
+
 from expression.core import Failure, Success, Try, match
-from hypothesis import given
-from hypothesis import strategies as st
 
 from .utils import CustomException
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,6 +1,7 @@
 from typing import Any, List, cast
 
 import pytest
+
 from expression.core.typing import downcast, try_downcast, upcast
 
 


### PR DESCRIPTION
This PR enables running code checks as pre-commit hooks for a shorter feedback loop. Install the hooks by running:
```
pre-commit install
```

We also now run all the code checks as part of the CI pipeline. 

I took the liberty of adding isort and autoflake aswell - these will sort and remove unused imports.