### PR TITLE
Fix match of generic type

### DIFF
--- a/expression/collections/frozenlist.py
+++ b/expression/collections/frozenlist.py
@@ -161,9 +161,15 @@ class FrozenList(Generic[TSource]):
         return FrozenList(xs)
 
     def cons(self, element: TSource) -> FrozenList[TSource]:
-        """Add element to front of List."""
+        """Add element to front of list."""
 
         return FrozenList((element,) + self.value)  # NOTE: Faster than (element, *self)
+
+    @staticmethod
+    def empty() -> FrozenList[TSource]:
+        """Returns empty list."""
+
+        return FrozenList()
 
     def filter(self, predicate: Callable[[TSource], bool]) -> FrozenList[TSource]:
         """Filter list.

--- a/expression/collections/seq.py
+++ b/expression/collections/seq.py
@@ -81,6 +81,11 @@ class Seq(Iterable[TSource]):
         xs = pipe(self, collect(mapping))
         return Seq(xs)
 
+    @staticmethod
+    def empty() -> Seq[TSource]:
+        """Returns empty sequence."""
+        return Seq()
+
     def fold(self, folder: Callable[[TState, TSource], TState], state: TState) -> TState:
         """Applies a function to each element of the collection,
         threading an accumulator argument through the computation. If

--- a/expression/core/match.py
+++ b/expression/core/match.py
@@ -80,7 +80,7 @@ class Case(Generic[TSource]):
     #     ...
 
     @overload
-    def __call__(self, pattern: Type[TSource]) -> Iterable[TSource]:
+    def __call__(self, pattern: Type[A]) -> Iterable[A]:
         """Match with type pattern.
 
         Handle the case where pattern is a type e.g `int`, `str`,

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,5 +1,6 @@
-from typing import Any, Iterable
+from typing import Any, Iterable, List
 
+from expression.collections import FrozenList
 from expression.core import Nothing, Option, Some, SupportsMatch, match
 
 
@@ -28,7 +29,7 @@ def test_match_type() -> None:
 
 def test_not_match_type() -> None:
     with match(42) as case:
-        if case(float):  # NOTE: Should show type error
+        if case(float):
             assert False
 
         if case._:
@@ -72,6 +73,13 @@ def test_match_not_equals() -> None:
             assert True
 
 
+def test_match_destructure() -> None:
+    xs: FrozenList[int] = FrozenList.empty().cons(42)
+    with match(xs) as case:
+        for (head, *_) in case(FrozenList[int]):
+            assert head == 42
+
+
 class A:
     pass
 
@@ -100,13 +108,13 @@ def test_not_match_isinstance() -> None:
 
 def test_match_multiple_cases() -> None:
     with match("expression") as case:
-        while case("rxpy"):  # NOTE: should show type error
+        while case("rxpy"):
             assert False
 
         for value in case(str):
             assert value == "expression"
 
-        for value in case(float):  # NOTE: should show type error
+        for value in case(float):
             assert False
 
         if case._:
@@ -182,3 +190,11 @@ def test_active_pattern_not_matches() -> None:
 
         if case._:
             assert True
+
+
+def test_match_generic_matches() -> None:
+    xs = [1, 2, 3]
+
+    with match(xs) as case:
+        for x in case(List[int]):
+            assert x == xs


### PR DESCRIPTION
- Fix match by not binding pattern to generic type of Case class. We still need the generic type of the Case class for default handling etc. 
- Add empty static constructors for seq and frozenlist.


Without this fix, `x` below will show type as `Type[List[int]]` and not `List[int]`:

```python
xs = [1, 2, 3]

with match(xs) as case:
    for x in case(List[int]):
        assert x == xs
```