### PR TITLE
Update to pyright 1.1.98

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,6 @@ repos:
     language: node
     pass_filenames: false
     types: [python]
-    additional_dependencies: ['pyright@1.1.97']
+    additional_dependencies: ['pyright@1.1.98']
   repo: local
   

--- a/expression/core/result.py
+++ b/expression/core/result.py
@@ -31,7 +31,7 @@ T3 = TypeVar("T3")
 T4 = TypeVar("T4")
 
 
-class Result(Iterable[Union[TSource, TError]], SupportsMatch[Union[TSource, TError]], ABC):
+class Result(Iterable[TSource], SupportsMatch[Union[TSource, TError]], ABC):
     """The result abstract base class."""
 
     @overload


### PR DESCRIPTION
- Fix typing bug in Result. Should be Iterable of TSource only
- Add generic types to Result match to infer the value / error correctly