### PR TITLE
Add mapi, append and delay for Seq and FrozenList

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,30 @@
 exclude: "_version.py|versioneer.py"
 repos:
-- hooks:
-    - args:
-        - --remove-all-unused-imports
-        - --in-place
-      id: autoflake
-  repo: https://github.com/humitos/mirrors-autoflake
-  rev: v1.1
-- hooks:
-    - id: isort
-  repo: https://github.com/timothycrosley/isort
-  rev: 5.6.4
-- hooks:
-    - id: black
-  repo: https://github.com/psf/black
-  rev: 20.8b1
-- hooks:
-    - id: flake8
-  repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.4
-- hooks:
-  - id: pyright
-    name: pyright
-    entry: pyright
-    language: node
-    pass_filenames: false
-    types: [python]
-    additional_dependencies: ['pyright@1.1.102']
-  repo: local
-  
+  - hooks:
+      - args:
+          - --remove-all-unused-imports
+          - --in-place
+        id: autoflake
+    repo: https://github.com/humitos/mirrors-autoflake
+    rev: v1.1
+  - hooks:
+      - id: isort
+    repo: https://github.com/timothycrosley/isort
+    rev: 5.6.4
+  - hooks:
+      - id: black
+    repo: https://github.com/psf/black
+    rev: 20.8b1
+  - hooks:
+      - id: flake8
+    repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+  - hooks:
+      - id: pyright
+        name: pyright
+        entry: pyright
+        language: node
+        pass_filenames: false
+        types: [python]
+        additional_dependencies: ["pyright@1.1.104"]
+    repo: local

--- a/expression/collections/frozenlist.py
+++ b/expression/collections/frozenlist.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import builtins
 import functools
+import itertools
 from typing import (
     Any,
     Callable,
@@ -267,6 +268,23 @@ class FrozenList(Generic[TSource]):
             The list of transformed elements.
         """
         return FrozenList((*builtins.map(mapping, self),))
+
+    def mapi(self, mapping: Callable[[int, TSource], TResult]) -> FrozenList[TResult]:
+        """Map list with index.
+
+        Builds a new collection whose elements are the results of
+        applying the given function to each of the elements of the
+        collection. The integer index passed to the function indicates
+        the index (from 0) of element being transformed.
+
+        Args:
+            mapping: The function to transform elements and their
+                indices.
+
+        Returns:
+            The list of transformed elements.
+        """
+        return FrozenList((*itertools.starmap(mapping, enumerate(self)),))
 
     @staticmethod
     def of(*args: TSource) -> FrozenList[TSource]:
@@ -625,6 +643,28 @@ def map(mapper: Callable[[TSource], TResult]) -> Projection[TSource, TResult]:
     return _map
 
 
+def mapi(mapper: Callable[[int, TSource], TResult]) -> Projection[TSource, TResult]:
+    """Map list with index.
+
+    Builds a new collection whose elements are the results of
+    applying the given function to each of the elements of the
+    collection. The integer index passed to the function indicates
+    the index (from 0) of element being transformed.
+
+    Args:
+        mapping: The function to transform elements and their
+            indices.
+
+    Returns:
+        The list of transformed elements.
+    """
+
+    def _mapi(source: FrozenList[TSource]) -> FrozenList[TResult]:
+        return source.mapi(mapper)
+
+    return _mapi
+
+
 def of(*args: TSource) -> FrozenList[TSource]:
     """Create list from a number of arguments."""
     return FrozenList((*args,))
@@ -812,6 +852,7 @@ __all__ = [
     "item",
     "is_empty",
     "map",
+    "mapi",
     "of_seq",
     "of_option",
     "singleton",

--- a/expression/core/aiotools.py
+++ b/expression/core/aiotools.py
@@ -68,7 +68,7 @@ def start(computation: Awaitable[Any], token: Optional[CancellationToken] = None
 def start_immediate(computation: Awaitable[Any], token: Optional[CancellationToken] = None) -> None:
     task = asyncio.create_task(computation)
 
-    def cb():
+    def cb() -> None:
         task.cancel()
 
     if token:
@@ -76,7 +76,7 @@ def start_immediate(computation: Awaitable[Any], token: Optional[CancellationTok
     return None
 
 
-def run_synchronous(computation: Awaitable[TSource]) -> TSource:
+def run_synchronously(computation: Awaitable[TSource]) -> TSource:
     """Runs the asynchronous computation and await its result."""
     return asyncio.run(computation)
 
@@ -114,4 +114,5 @@ __all__ = [
     "sleep",
     "start",
     "start_immediate",
+    "run_synchronously",
 ]

--- a/expression/core/misc.py
+++ b/expression/core/misc.py
@@ -20,7 +20,7 @@ def starid(*value: Any) -> Tuple[Any, ...]:
     return value
 
 
-def flip(fn: Callable[[A, B], Any]) -> Callable[[B, A], Any]:
+def flip(fn: Callable[[A, B], TResult]) -> Callable[[B, A], TResult]:
     """Flips the arguments for a function taking two arguments.
 
     Example:
@@ -33,14 +33,14 @@ def flip(fn: Callable[[A, B], Any]) -> Callable[[B, A], Any]:
     return _flip
 
 
-def snd(value: Tuple[Any, B]) -> B:
+def snd(value: Tuple[Any, TSource]) -> TSource:
     """Return second argument of the tuple."""
 
     _, b = value
     return b
 
 
-def fst(value: Tuple[A, Any]) -> A:
+def fst(value: Tuple[TSource, Any]) -> TSource:
     """Return first argument of the tuple."""
 
     a, _ = value

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -101,6 +101,18 @@ def test_list_pipe_map(xs: List[int]):
 
 
 @given(st.lists(st.integers()))
+def test_list_pipe_mapi(xs: List[int]):
+    def mapper(i: int, x: int):
+        return x + i
+
+    ys = frozenlist.of_seq(xs)
+    zs = ys.pipe(frozenlist.mapi(mapper))
+
+    assert isinstance(zs, FrozenList)
+    assert [z for z in zs] == [x + i for i, x in enumerate(xs)]
+
+
+@given(st.lists(st.integers()))
 def test_list_len(xs: List[int]):
     ys = frozenlist.of_seq(xs)
     assert len(xs) == len(ys)

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -212,6 +212,22 @@ def test_seq_pipeline(xs: List[int]):
     assert ys == functools.reduce(lambda s, x: s + x, filter(lambda x: x > 100, map(lambda x: x * 10, xs)), 0)
 
 
+@given(st.lists(st.integers()))
+def test_seq_delay(xs: List[int]):
+    ran = False
+
+    def generator():
+        nonlocal ran
+        ran = True
+        return seq.of_list(xs)
+
+    ys = seq.delay(generator)
+    assert not ran
+
+    assert list(ys) == xs
+    assert ran
+
+
 def test_seq_choose_option():
     xs: Iterable[Optional[int]] = seq.of(None, 42)
 

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -67,6 +67,15 @@ def test_seq_pipe_map(xs: List[int]):
     assert [y for y in ys] == [x + 1 for x in xs]
 
 
+@given(st.lists(st.integers()))
+def test_seq_pipe_mapi(xs: List[int]):
+    mapper: Callable[[int, int], int] = lambda i, x: x + i
+    ys = pipe(xs, seq.mapi(mapper))
+
+    assert isinstance(ys, Iterable)
+    assert [y for y in ys] == [x + i for i, x in enumerate(xs)]
+
+
 @given(st.lists(st.integers(), min_size=1))
 def test_seq_head_pipe(xs: List[int]):
     value = pipe(xs, seq.head)
@@ -130,24 +139,45 @@ def test_seq_scan_fluent(xs: List[int], s: int):
 
 
 @given(st.lists(st.integers()))
-def test_seq_concat_pipe(xs: List[int]):
+def test_seq_concat_1(xs: List[int]):
     value = seq.concat(xs)
 
     assert list(value) == xs
 
 
 @given(st.lists(st.integers()), st.lists(st.integers()))
-def test_seq_concat_pipe2(xs: List[int], ys: List[int]):
+def test_seq_concat_2(xs: List[int], ys: List[int]):
     value = seq.concat(xs, ys)
 
     assert list(value) == xs + ys
 
 
 @given(st.lists(st.integers()), st.lists(st.integers()), st.lists(st.integers()))
-def test_seq_concat_pipe3(xs: List[int], ys: List[int], zs: List[int]):
+def test_seq_concat_3(xs: List[int], ys: List[int], zs: List[int]):
     value = seq.concat(xs, ys, zs)
 
     assert list(value) == xs + ys + zs
+
+
+@given(st.lists(st.integers()), st.lists(st.integers()))
+def test_seq_append_2(xs: List[int], ys: List[int]):
+    value = pipe(xs, seq.append(ys))
+
+    assert list(value) == xs + ys
+
+
+@given(st.lists(st.integers()), st.lists(st.integers()), st.lists(st.integers()))
+def test_seq_append_3(xs: List[int], ys: List[int], zs: List[int]):
+    value = pipe(xs, seq.append(ys, zs))
+
+    assert list(value) == xs + ys + zs
+
+
+@given(st.lists(st.integers()), st.lists(st.integers()))
+def test_seq_append_flient(xs: List[int], ys: List[int]):
+    value = Seq(xs).append(ys)
+
+    assert list(value) == xs + ys
 
 
 @given(st.lists(st.integers()))


### PR DESCRIPTION
- Add seq delay, mapi, append operators
- Add list mapi operator
- Upgrade pyright to 1.1.104
- Rename `run_synchronous` to `run_synchronously` to match F# `runSynchronously`
- Fix type annotations in async module (aiotools)