### PR TITLE
Pyright upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,5 +26,5 @@ repos:
         language: node
         pass_filenames: false
         types: [python]
-        additional_dependencies: ["pyright@1.1.127"]
+        additional_dependencies: ["pyright@1.1.158"]
     repo: local

--- a/expression/collections/asyncseq.py
+++ b/expression/collections/asyncseq.py
@@ -63,21 +63,21 @@ async def repeat(value: TSource, times: Optional[int] = None) -> AsyncIterable[T
 
 
 @overload
-async def range(stop: int) -> AsyncIterable[int]:
+def range(stop: int) -> AsyncIterable[int]:
     ...
 
 
 @overload
-async def range(start: int, stop: int) -> AsyncIterable[int]:
+def range(start: int, stop: int) -> AsyncIterable[int]:
     ...
 
 
 @overload
-async def range(start: int, stop: int, step: int) -> AsyncIterable[int]:
+def range(start: int, stop: int, step: int) -> AsyncIterable[int]:
     ...
 
 
-async def range(*args: Any, **kw: Any) -> AsyncIterable[Any]:
+async def range(*args: int, **kw: int) -> AsyncIterable[int]:
     for value in builtins.range(*args, **kw):
         yield value
 

--- a/expression/collections/frozenlist.py
+++ b/expression/collections/frozenlist.py
@@ -30,7 +30,6 @@ from typing import (
     Iterator,
     List,
     Optional,
-    Protocol,
     Tuple,
     TypeVar,
     cast,
@@ -438,8 +437,8 @@ class FrozenList(Generic[TSource]):
     def __iter__(self) -> Iterator[TSource]:
         return iter(self.value)
 
-    def __eq__(self, other: Any) -> bool:
-        return self.value == other
+    def __eq__(self, o: Any) -> bool:
+        return self.value == o
 
     def __len__(self) -> int:
         return len(self.value)
@@ -462,20 +461,6 @@ class FrozenList(Generic[TSource]):
 
     def __repr__(self) -> str:
         return str(self)
-
-
-class Cata(Protocol[TSourceIn, TResultOut]):
-    """A partially applied exit function."""
-
-    def __call__(self, source: FrozenList[TSourceIn]) -> TResultOut:
-        ...
-
-
-class Projection(Protocol[TSourceIn, TResultOut]):
-    """A partially applied filter function."""
-
-    def __call__(self, __source: FrozenList[TSourceIn]) -> FrozenList[TResultOut]:
-        ...
 
 
 def append(source: FrozenList[TSource]) -> Callable[[FrozenList[TSource]], FrozenList[TSource]]:
@@ -634,7 +619,7 @@ def indexed(source: FrozenList[TSource]) -> FrozenList[Tuple[int, TSource]]:
     return source.indexed()
 
 
-def item(index: int) -> Cata[TSource, TSource]:
+def item(index: int) -> Callable[[FrozenList[TSource]], TSource]:
     """Indexes into the list. The first element has index 0.
 
     Args:
@@ -655,7 +640,7 @@ def is_empty(source: FrozenList[Any]) -> bool:
     return source.is_empty()
 
 
-def map(mapper: Callable[[TSource], TResult]) -> Projection[TSource, TResult]:
+def map(mapper: Callable[[TSource], TResult]) -> Callable[[FrozenList[TSource]], FrozenList[TResult]]:
     """Map list.
 
     Builds a new collection whose elements are the results of applying
@@ -674,7 +659,7 @@ def map(mapper: Callable[[TSource], TResult]) -> Projection[TSource, TResult]:
     return _map
 
 
-def mapi(mapper: Callable[[int, TSource], TResult]) -> Projection[TSource, TResult]:
+def mapi(mapper: Callable[[int, TSource], TResult]) -> Callable[[FrozenList[TSource]], FrozenList[TResult]]:
     """Map list with index.
 
     Builds a new collection whose elements are the results of
@@ -735,7 +720,7 @@ def singleton(value: TSource) -> FrozenList[TSource]:
     return FrozenList((value,))
 
 
-def skip(count: int) -> Projection[TSource, TSource]:
+def skip(count: int) -> Callable[[FrozenList[TSource]], FrozenList[TSource]]:
     """Returns the list after removing the first N elements.
 
     Args:
@@ -751,7 +736,7 @@ def skip(count: int) -> Projection[TSource, TSource]:
     return _skip
 
 
-def skip_last(count: int) -> Projection[TSource, TSource]:
+def skip_last(count: int) -> Callable[[FrozenList[TSource]], FrozenList[TSource]]:
     """Returns the list after removing the last N elements.
 
     Args:
@@ -771,7 +756,7 @@ def tail(source: FrozenList[TSource]) -> FrozenList[TSource]:
     return source.tail()
 
 
-def take(count: int) -> Projection[TSource, TSource]:
+def take(count: int) -> Callable[[FrozenList[TSource]], FrozenList[TSource]]:
     """Returns the first N elements of the list.
 
     Args:
@@ -787,7 +772,7 @@ def take(count: int) -> Projection[TSource, TSource]:
     return _take
 
 
-def take_last(count: int) -> Projection[TSource, TSource]:
+def take_last(count: int) -> Callable[[FrozenList[TSource]], FrozenList[TSource]]:
     """Returns a specified number of contiguous elements from the end of
     the list.
 

--- a/expression/collections/map.py
+++ b/expression/collections/map.py
@@ -248,8 +248,8 @@ class Map(Mapping[Key, Value]):
             res = combine_hash(res, hash(y))
         return res
 
-    def __getitem__(self, key: Key) -> Value:
-        return maptree.find(key, self._tree)
+    def __getitem__(self, k: Key) -> Value:
+        return maptree.find(k, self._tree)
 
     def __iter__(self) -> Iterator[Key]:
         xs = maptree.mk_iterator(self._tree)
@@ -259,14 +259,14 @@ class Map(Mapping[Key, Value]):
         """Return the number of bindings in the map."""
         return maptree.size(self._tree)
 
-    def __contains__(self, key: Any) -> bool:
-        return self.contains_key(key)
+    def __contains__(self, o: Any) -> bool:
+        return self.contains_key(o)
 
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, Map):
+    def __eq__(self, o: Any) -> bool:
+        if not isinstance(o, Map):
             return False
 
-        other = cast(Map[Any, Any], other)
+        other = cast(Map[Any, Any], o)
         iterator: Iterator[Tuple[Any, Any]] = iter(other.to_seq())
 
         for kv in self.to_seq():

--- a/expression/collections/seq.py
+++ b/expression/collections/seq.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import builtins
 import functools
 import itertools
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Optional, Protocol, Tuple, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Optional, Tuple, TypeVar, cast, overload
 
 from expression.core import Case, Option, SupportsLessThan, identity, pipe
 
@@ -350,18 +350,7 @@ class SeqGen(Iterable[TSource]):
         return builtins.iter(xs)
 
 
-class Projection(Protocol[TSourceIn, TResultOut]):
-    """Sequence transformation protocol.
-
-    A sequence transformation protocol that encapsulates a function of
-    type `Iterable[TSource]) -> Iterable[TResult]`
-    """
-
-    def __call__(self, __source: Iterable[TSourceIn]) -> Iterable[TResultOut]:
-        raise NotImplementedError
-
-
-def append(*others: Iterable[TSource]) -> Projection[TSource, TSource]:
+def append(*others: Iterable[TSource]) -> Callable[[Iterable[TSource]], Iterable[TSource]]:
     """Wraps the given enumerations as a single concatenated
     enumeration."""
 
@@ -371,7 +360,7 @@ def append(*others: Iterable[TSource]) -> Projection[TSource, TSource]:
     return _
 
 
-def choose(chooser: Callable[[TSource], Option[TResult]]) -> Projection[TSource, TResult]:
+def choose(chooser: Callable[[TSource], Option[TResult]]) -> Callable[[Iterable[TSource]], Iterable[TResult]]:
     """Choose items from the sequence.
 
     Applies the given function to each element of the list. Returns
@@ -395,7 +384,7 @@ def choose(chooser: Callable[[TSource], Option[TResult]]) -> Projection[TSource,
     return _choose
 
 
-def collect(mapping: Callable[[TSource], Iterable[TResult]]) -> Projection[TSource, TResult]:
+def collect(mapping: Callable[[TSource], Iterable[TResult]]) -> Callable[[Iterable[TSource]], Iterable[TResult]]:
     def _collect(source: Iterable[TSource]) -> Iterable[TResult]:
         def gen():
             for xs in source:
@@ -444,7 +433,7 @@ empty: Seq[Any] = Seq()
 """The empty sequence."""
 
 
-def filter(predicate: Callable[[TSource], bool]) -> Projection[TSource, TSource]:
+def filter(predicate: Callable[[TSource], bool]) -> Callable[[Iterable[TSource]], Iterable[TSource]]:
     """Filter sequence.
 
     Filters the sequence to a new sequence containing only the
@@ -609,7 +598,7 @@ def length(source: Seq[Any]) -> int:
     return builtins.sum(1 for _ in source)
 
 
-def map(mapper: Callable[[TSource], TResult]) -> Projection[TSource, TResult]:
+def map(mapper: Callable[[TSource], TResult]) -> Callable[[Iterable[TSource]], Iterable[TResult]]:
     """Map source sequence.
 
     Builds a new collection whose elements are the results of
@@ -641,7 +630,7 @@ def map(mapper: Callable[[TSource], TResult]) -> Projection[TSource, TResult]:
     return _map
 
 
-def mapi(mapping: Callable[[int, TSource], TResult]) -> Projection[TSource, TResult]:
+def mapi(mapping: Callable[[int, TSource], TResult]) -> Callable[[Iterable[TSource]], Iterable[TResult]]:
     """Map list with index.
 
     Builds a new collection whose elements are the results of
@@ -766,7 +755,7 @@ def singleton(item: TSource) -> Seq[TSource]:
     return Seq([item])
 
 
-def skip(count: int) -> Projection[Any, Any]:
+def skip(count: int) -> Callable[[Iterable[TSource]], Iterable[TSource]]:
     """Returns a sequence that skips N elements of the underlying
     sequence and then yields the remaining elements of the sequence.
 
@@ -809,7 +798,7 @@ def tail(source: Iterable[TSource]) -> Iterable[TSource]:
     return proj(source)
 
 
-def take(count: int) -> Projection[Any, Any]:
+def take(count: int) -> Callable[[Iterable[TSource]], Iterable[TSource]]:
     """Returns the first N elements of the sequence.
 
     Args:
@@ -932,7 +921,6 @@ __all__ = [
     "sum_by",
     "tail",
     "take",
-    "Projection",
     "unfold",
     "zip",
 ]

--- a/expression/core/aiotools.py
+++ b/expression/core/aiotools.py
@@ -44,7 +44,7 @@ def from_continuations(callback: Callbacks[TSource]) -> Awaitable[TSource]:
         future.cancel()
 
     callback(done, error, cancel)
-    return asyncio.ensure_future(future)
+    return future
 
 
 def start(computation: Awaitable[Any], token: Optional[CancellationToken] = None) -> None:
@@ -66,6 +66,8 @@ def start(computation: Awaitable[Any], token: Optional[CancellationToken] = None
 
 
 def start_immediate(computation: Awaitable[Any], token: Optional[CancellationToken] = None) -> None:
+    """Runs an asynchronous computation, starting immediately on the
+    current operating system thread."""
     task = asyncio.create_task(computation)
 
     def cb() -> None:
@@ -99,6 +101,9 @@ async def empty() -> None:
 
 
 def from_result(result: TSource) -> Awaitable[TSource]:
+    """Creates a async operation that's completed successfully with the
+    specified result."""
+
     async def from_result(result: TSource) -> TSource:
         """Async return value"""
         return result

--- a/expression/core/choice.py
+++ b/expression/core/choice.py
@@ -69,9 +69,9 @@ class Choice1of2(Choice2[A, B], Choice[A]):
     def match(cls, case: Any) -> Iterable[Any]:
         return case(cls)
 
-    def __eq__(self, other: Any) -> bool:
-        if isinstance(other, Choice1of2):
-            return self.value == other.value
+    def __eq__(self, o: Any) -> bool:
+        if isinstance(o, Choice1of2):
+            return self.value == o.value
         return False
 
     def __str__(self) -> str:
@@ -103,9 +103,9 @@ class Choice2of2(Choice2[A, B], Choice[B]):
     def match(cls, case: Any) -> Iterable[Any]:
         return case(cls)
 
-    def __eq__(self, other: Any) -> bool:
-        if isinstance(other, Choice2of2):
-            return self.value == other.value
+    def __eq__(self, o: Any) -> bool:
+        if isinstance(o, Choice2of2):
+            return self.value == o.value
         return False
 
     def __str__(self) -> str:

--- a/expression/core/option.py
+++ b/expression/core/option.py
@@ -17,7 +17,6 @@ from typing import (
     Iterator,
     List,
     Optional,
-    Protocol,
     TypeVar,
     Union,
     cast,
@@ -106,7 +105,7 @@ class Option(Iterable[TSource], MatchMixin[TSource], SupportsMatch[Union[TSource
 
     @abstractmethod
     def or_else(self, if_none: Option[TSource]) -> Option[TSource]:
-        """Returns option if it is Some, otherwise returns `if_one`. """
+        """Returns option if it is Some, otherwise returns `if_one`."""
         raise NotImplementedError
 
     @abstractmethod
@@ -159,7 +158,7 @@ class Option(Iterable[TSource], MatchMixin[TSource], SupportsMatch[Union[TSource
         raise NotImplementedError
 
     @abstractmethod
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, o: Any) -> bool:
         raise NotImplementedError
 
     @abstractmethod
@@ -261,9 +260,9 @@ class Some(Option[TSource]):
             return self._value < other._value  # type: ignore
         return False
 
-    def __eq__(self, other: Any) -> bool:
-        if isinstance(other, Some):
-            return self._value == other._value  # type: ignore
+    def __eq__(self, o: Any) -> bool:
+        if isinstance(o, Some):
+            return self._value == o._value  # type: ignore
         return False
 
     def __iter__(self) -> Generator[TSource, TSource, TSource]:
@@ -366,23 +365,13 @@ class Nothing_(Option[TSource], EffectError):
     def __lt__(self, other: Any) -> bool:
         return True
 
-    def __eq__(self, other: Any) -> bool:
-        if other is Nothing:
+    def __eq__(self, o: Any) -> bool:
+        if o is Nothing:
             return True
         return False
 
     def __str__(self):
         return "Nothing"
-
-
-class Projection(Protocol[TSourceIn, TResultOut]):
-    """Option transforming protocol function.
-
-    `Option[TSource]) -> Option[TResult]`
-    """
-
-    def __call__(self, __source: Option[TSourceIn]) -> Option[TResultOut]:
-        raise NotImplementedError
 
 
 # The singleton None class. We use the name 'Nothing' here instead of `None` to
@@ -397,7 +386,7 @@ Since Nothing is a singleton it can be tested e.g using `is`:
 """
 
 
-def bind(mapper: Callable[[TSource], Option[TResult]]) -> Projection[TSource, TResult]:
+def bind(mapper: Callable[[TSource], Option[TResult]]) -> Callable[[Option[TSource]], Option[TResult]]:
     """Bind option.
 
     Applies and returns the result of the mapper if the value is
@@ -438,7 +427,7 @@ def is_some(option: Option[Any]) -> bool:
     return option.is_some()
 
 
-def map(mapper: Callable[[TSource], TResult]) -> Projection[TSource, TResult]:
+def map(mapper: Callable[[TSource], TResult]) -> Callable[[Option[TSource]], Option[TResult]]:
     def _map(option: Option[TSource]) -> Option[TResult]:
         return option.map(mapper)
 
@@ -528,5 +517,4 @@ __all__ = [
     "to_seq",
     "of_optional",
     "of_obj",
-    "Projection",
 ]

--- a/expression/core/result.py
+++ b/expression/core/result.py
@@ -11,7 +11,7 @@ the Result type to Exception.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Generator, Iterable, Iterator, Protocol, Type, TypeVar, Union, get_origin, overload
+from typing import Any, Callable, Generator, Iterable, Iterator, Type, TypeVar, Union, get_origin, overload
 
 from .error import EffectError
 from .match import Case, SupportsMatch
@@ -116,7 +116,7 @@ class Result(Iterable[TSource], SupportsMatch[Union[TSource, TError]], ABC):
 
         raise NotImplementedError
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, o: Any) -> bool:
         raise NotImplementedError
 
     @abstractmethod
@@ -171,9 +171,9 @@ class Ok(Result[TSource, TError], SupportsMatch[TSource]):
 
         return []
 
-    def __eq__(self, other: Any) -> bool:
-        if isinstance(other, Ok):
-            return self.value == other.value  # type: ignore
+    def __eq__(self, o: Any) -> bool:
+        if isinstance(o, Ok):
+            return self.value == o.value  # type: ignore
         return False
 
     def __iter__(self) -> Generator[TSource, TSource, TSource]:
@@ -235,9 +235,9 @@ class Error(Result[TSource, TError], ResultException):
 
         return []
 
-    def __eq__(self, other: Any) -> bool:
-        if isinstance(other, Error):
-            return self.error == other.error  # type: ignore
+    def __eq__(self, o: Any) -> bool:
+        if isinstance(o, Error):
+            return self.error == o.error  # type: ignore
         return False
 
     def __iter__(self) -> Iterator[TSource]:
@@ -254,19 +254,16 @@ class Error(Result[TSource, TError], ResultException):
         return f"Error {self._error}"
 
 
-class Projection(Protocol[TSourceIn, TResultOut]):
-    def __call__(self, __source: Result[TSourceIn, TError]) -> Result[TResultOut, TError]:
-        ...
-
-
-def map(mapper: Callable[[TSource], TResult]) -> Projection[TSource, TResult]:
+def map(mapper: Callable[[TSource], TResult]) -> Callable[[Result[TSource, TError]], Result[TResult, TError]]:
     def _map(result: Result[TSource, TError]) -> Result[TResult, TError]:
         return result.map(mapper)
 
     return _map
 
 
-def bind(mapper: Callable[[TSource], Result[TResult, Any]]) -> Projection[TSource, TResult]:
+def bind(
+    mapper: Callable[[TSource], Result[TResult, Any]]
+) -> Callable[[Result[TSource, TError]], Result[TResult, TError]]:
     def _bind(result: Result[TSource, TError]) -> Result[TResult, TError]:
         return result.bind(mapper)
 
@@ -279,5 +276,4 @@ __all__ = [
     "Error",
     "map",
     "bind",
-    "Projection",
 ]

--- a/expression/system/error.py
+++ b/expression/system/error.py
@@ -1,6 +1,6 @@
 class ObjectDisposedException(Exception):
     def __init__(self):
-        super().__init__("The operation was canceled")
+        super().__init__("Cannot access a disposed object")
 
 
 class OperationCanceledError(Exception):

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -6,5 +6,7 @@
   "exclude": [
     "expression/_version.py"
   ],
-  "reportImportCycles": false
+  "reportImportCycles": false,
+  "reportMissingImports": false,
+  "pythonVersion": "3.9",
 }

--- a/tests/test_catch.py
+++ b/tests/test_catch.py
@@ -3,13 +3,13 @@ from typing import Any, Generator
 import pytest
 
 from expression import effect
-from expression.core import Error, Ok
+from expression.core import Error, Ok, Result
 from expression.extra.result import catch
 
 
 def test_catch_wraps_ok():
     @catch(exception=ValueError)
-    def add(a: int, b: int) -> int:
+    def add(a: int, b: int) -> Any:
         return a + b
 
     assert add(3, 4) == Ok(7)
@@ -17,7 +17,7 @@ def test_catch_wraps_ok():
 
 def test_catch_wraps_error():
     @catch(exception=ValueError)
-    def fn() -> None:
+    def fn() -> Any:
         raise ValueError("error")
 
     result = fn()
@@ -31,7 +31,7 @@ def test_catch_wraps_error():
 
 def test_catch_ignores_other_exceptions():
     @catch(exception=KeyError)
-    def fn(ex: Exception) -> None:
+    def fn(ex: Exception) -> Result[int, Exception]:
         raise ex
 
     with pytest.raises(ValueError):
@@ -44,7 +44,7 @@ def test_catch_ignores_other_exceptions():
 def test_catch_chained():
     @catch(exception=KeyError)
     @catch(exception=ValueError)
-    def fn(ex: Exception) -> None:
+    def fn(ex: Exception) -> Any:
         raise ex
 
     result = fn(ValueError("error"))

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -273,7 +273,7 @@ def test_list_monad_law_left_identity(value: int):
 
 @given(st.integers())
 def test_list_monad_law_right_identity(value: int):
-    r"""Monad law right identit.
+    r"""Monad law right identity.
 
     m >>= return is no different than just m.
     """

--- a/tests/test_seq.py
+++ b/tests/test_seq.py
@@ -127,7 +127,8 @@ def test_seq_scan_pipe(xs: List[int], s: int):
     func: Callable[[int, int], int] = lambda s, v: s + v
     value = pipe(seq.of_iterable(xs), seq.scan(func, s))
 
-    assert list(value) == list(accumulate(xs, func, initial=s))
+    expected: Iterable[int] = accumulate(xs, func, initial=s)
+    assert list(value) == list(expected)
 
 
 @given(st.lists(st.integers(), min_size=1), st.integers())
@@ -135,7 +136,8 @@ def test_seq_scan_fluent(xs: List[int], s: int):
     func: Callable[[int, int], int] = lambda s, v: s + v
     value = seq.of_iterable(xs).scan(func, s)
 
-    assert list(value) == list(accumulate(xs, func, initial=s))
+    expected: Iterable[int] = accumulate(xs, func, initial=s)
+    assert list(value) == list(expected)
 
 
 @given(st.lists(st.integers()))
@@ -182,7 +184,7 @@ def test_seq_append_fluent(xs: List[int], ys: List[int]):
 
 @given(st.lists(st.integers()))
 def test_seq_collect(xs: List[int]):
-    collector: seq.Projection[int, int] = seq.collect(seq.singleton)
+    collector = seq.collect(seq.singleton)
     ys = pipe(xs, collector)
 
     assert list(xs) == list(ys)
@@ -255,7 +257,7 @@ def test_seq_delay(xs: List[int]):
 def test_seq_choose_option():
     xs: Iterable[Optional[int]] = seq.of(None, 42)
 
-    chooser: seq.Projection[Optional[int], int] = seq.choose(option.of_optional)
+    chooser = seq.choose(option.of_optional)
     ys = pipe(xs, chooser)
 
     assert list(ys) == [42]


### PR DESCRIPTION
- Upgrade Pyright to 1.1.158
- Typing cleanup (no need for typing protocols, finally)