### PR TITLE
Fix typing errors in #39

### DIFF
--- a/expression/collections/frozenlist.py
+++ b/expression/collections/frozenlist.py
@@ -356,6 +356,33 @@ class FrozenList(Generic[TSource]):
         _, *tail = self.value
         return FrozenList(tail)
 
+    def sort(self, reverse: bool = False) -> FrozenList[TSource]:
+        """Sort list directly.
+
+        Returns a new sorted collection.
+
+        Args:
+            reverse: Sort in reversed order.
+
+        Returns:
+            A sorted list.
+        """
+        return FrozenList(builtins.sorted(self.value, reverse=reverse))
+
+    def sort_with(self, func: Callable[[TSource], Any], reverse: bool = False) -> FrozenList[TSource]:
+        """Sort list with supplied function.
+
+        Returns a new sorted collection.
+
+        Args:
+            func: The function to extract a comparison key from each element in list.
+            reverse: Sort in reversed order.
+
+        Returns:
+            A sorted list.
+        """
+        return FrozenList(builtins.sorted(self.value, key=func, reverse=reverse))
+
     def take(self, count: int) -> FrozenList[TSource]:
         """Returns the first N elements of the list.
 
@@ -752,6 +779,55 @@ def skip_last(count: int) -> Callable[[FrozenList[TSource]], FrozenList[TSource]
     return _skip_last
 
 
+def sort(reverse=False) -> Callable[[FrozenList[TSource]], FrozenList[TSource]]:
+    """Returns a new sorted collection
+
+    Args:
+        reverse: Sort in reversed order.
+
+    Returns:
+        Partially applied sort function.
+    """
+
+    def _sort(source: FrozenList[TSource]) -> FrozenList[TSource]:
+        """Returns a new sorted collection
+
+        Args:
+            source: The input list.
+
+        Returns:
+            A sorted list.
+        """
+        return source.sort(reverse)
+
+    return _sort
+
+
+def sort_with(func: Callable[[TSource], Any], reverse=False) -> Callable[[FrozenList[TSource]], FrozenList[TSource]]:
+    """Returns a new collection sorted using "func" key function.
+
+    Args:
+        func: The function to extract a comparison key from each element in list.
+        reverse: Sort in reversed order.
+
+    Returns:
+        Partially applied sort function.
+    """
+
+    def _sort_with(source: FrozenList[TSource]) -> FrozenList[TSource]:
+        """Returns a new collection sorted using "func" key function.
+
+        Args:
+            source: The input list.
+
+        Returns:
+            A sorted list.
+        """
+        return source.sort_with(func, reverse)
+
+    return _sort_with
+
+
 def tail(source: FrozenList[TSource]) -> FrozenList[TSource]:
     return source.tail()
 
@@ -874,6 +950,8 @@ __all__ = [
     "singleton",
     "skip",
     "skip_last",
+    "sort",
+    "sort_with",
     "tail",
     "take",
     "take_last",

--- a/expression/collections/frozenlist.py
+++ b/expression/collections/frozenlist.py
@@ -37,15 +37,17 @@ from typing import (
     overload,
 )
 
-from expression.core import Case, Nothing, Option, Some, pipe
+from expression.core import Case, Nothing, Option, Some, SupportsLessThan, pipe
 
 from . import seq
 
 TSource = TypeVar("TSource")
+TSourceSortable = TypeVar("TSourceSortable", bound=SupportsLessThan)
 TSourceIn = TypeVar("TSourceIn", contravariant=True)
 TResult = TypeVar("TResult")
 TResultOut = TypeVar("TResultOut", covariant=True)
 TState = TypeVar("TState")
+
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
 T3 = TypeVar("T3")
@@ -356,7 +358,7 @@ class FrozenList(Generic[TSource]):
         _, *tail = self.value
         return FrozenList(tail)
 
-    def sort(self, reverse: bool = False) -> FrozenList[TSource]:
+    def sort(self: FrozenList[TSourceSortable], reverse: bool = False) -> FrozenList[TSourceSortable]:
         """Sort list directly.
 
         Returns a new sorted collection.
@@ -779,7 +781,7 @@ def skip_last(count: int) -> Callable[[FrozenList[TSource]], FrozenList[TSource]
     return _skip_last
 
 
-def sort(reverse=False) -> Callable[[FrozenList[TSource]], FrozenList[TSource]]:
+def sort(reverse: bool = False) -> Callable[[FrozenList[TSourceSortable]], FrozenList[TSourceSortable]]:
     """Returns a new sorted collection
 
     Args:
@@ -789,7 +791,7 @@ def sort(reverse=False) -> Callable[[FrozenList[TSource]], FrozenList[TSource]]:
         Partially applied sort function.
     """
 
-    def _sort(source: FrozenList[TSource]) -> FrozenList[TSource]:
+    def _sort(source: FrozenList[TSourceSortable]) -> FrozenList[TSourceSortable]:
         """Returns a new sorted collection
 
         Args:
@@ -803,7 +805,9 @@ def sort(reverse=False) -> Callable[[FrozenList[TSource]], FrozenList[TSource]]:
     return _sort
 
 
-def sort_with(func: Callable[[TSource], Any], reverse=False) -> Callable[[FrozenList[TSource]], FrozenList[TSource]]:
+def sort_with(
+    func: Callable[[TSource], Any], reverse: bool = False
+) -> Callable[[FrozenList[TSource]], FrozenList[TSource]]:
     """Returns a new collection sorted using "func" key function.
 
     Args:

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -239,6 +239,25 @@ def test_list_filter(xs: List[int], limit: int):
     assert list(result) == list(expected)
 
 
+@given(st.lists(st.integers()))
+def test_list_sort(xs: List[int]):
+    expected = sorted(xs)
+    ys: FrozenList[int] = frozenlist.of_seq(xs)
+    result = pipe(ys, frozenlist.sort())
+
+    assert list(result) == list(expected)
+
+
+@given(st.lists(st.text(min_size=2)))
+def test_list_sort_with(xs: List[str]):
+    expected = sorted(xs, key=lambda x: x[1])
+    ys: FrozenList[str] = frozenlist.of_seq(xs)
+    func: Callable[[str], str] = lambda x: x[1]
+    result = pipe(ys, frozenlist.sort_with(func))
+
+    assert list(result) == list(expected)
+
+
 rtn: Callable[[int], FrozenList[int]] = frozenlist.singleton
 empty: FrozenList[Any] = frozenlist.empty
 


### PR DESCRIPTION
Fixes typing errors in #39 by only allowing sort on a sortable list (i.e where the elements supports less-than operator)