### PR TITLE
feat: rename curry_flipped to curry_flip

### DIFF
--- a/expression/__init__.py
+++ b/expression/__init__.py
@@ -40,7 +40,7 @@ from .core import (
     Try,
     compose,
     curry,
-    curry_flipped,
+    curry_flip,
     default_arg,
     downcast,
     failwith,
@@ -60,6 +60,12 @@ from .core import (
     upcast,
 )
 
+curry_flipped = curry_flip
+"""Deprecated.
+
+Will be removed in next major version. Use curry_flip instead.
+"""
+
 __all__ = [
     "AsyncReplyChannel",
     "Builder",
@@ -75,6 +81,7 @@ __all__ = [
     "compose",
     "core",
     "curry",
+    "curry_flip",
     "curry_flipped",
     "default_arg",
     "downcast",

--- a/expression/collections/block.py
+++ b/expression/collections/block.py
@@ -44,7 +44,7 @@ from expression.core import (
     Some,
     SupportsLessThan,
     SupportsSum,
-    curry_flipped,
+    curry_flip,
     pipe,
 )
 from expression.core.typing import GenericValidator, ModelField, SupportsValidation
@@ -602,7 +602,7 @@ def choose(
     return _choose
 
 
-@curry_flipped(1)
+@curry_flip(1)
 def collect(
     source: Block[_TSource], mapping: Callable[[_TSource], Block[_TResult]]
 ) -> Block[_TResult]:
@@ -639,7 +639,7 @@ empty: Block[Any] = nil
 """The empty list."""
 
 
-@curry_flipped(1)
+@curry_flip(1)
 def filter(
     source: Block[_TSource], predicate: Callable[[_TSource], bool]
 ) -> Block[_TSource]:
@@ -769,7 +769,7 @@ def map(
     return _map
 
 
-@curry_flipped(1)
+@curry_flip(1)
 def reduce(
     source: Block[_TSource],
     reduction: Callable[[_TSource, _TSource], _TSource],
@@ -892,7 +892,7 @@ def of_option(option: Option[_TSource]) -> Block[_TSource]:
     return empty
 
 
-@curry_flipped(1)
+@curry_flip(1)
 def partition(
     source: Block[_TSource], predicate: Callable[[_TSource], bool]
 ) -> Tuple[Block[_TSource], Block[_TSource]]:

--- a/expression/core/__init__.py
+++ b/expression/core/__init__.py
@@ -15,7 +15,7 @@ from .choice import (
     Choice3of3,
 )
 from .compose import compose
-from .curry import curry, curry_flipped
+from .curry import curry, curry_flip
 from .error import EffectError, failwith
 from .fn import TailCall, TailCallResult, tailrec, tailrec_async
 from .mailbox import AsyncReplyChannel, MailboxProcessor
@@ -49,7 +49,7 @@ __all__ = [
     "Choice3of3",
     "compose",
     "curry",
-    "curry_flipped",
+    "curry_flip",
     "default_arg",
     "downcast",
     "EffectError",

--- a/expression/core/curry.py
+++ b/expression/core/curry.py
@@ -113,21 +113,21 @@ def curry(num_args: _Arity) -> Callable[..., Any]:
 
 
 @overload
-def curry_flipped(
+def curry_flip(
     num_args: Literal[0],
 ) -> Callable[[Callable[_P, _A]], Callable[_P, _A]]:
     ...
 
 
 @overload
-def curry_flipped(
+def curry_flip(
     num_args: Literal[1],
 ) -> Callable[[Callable[Concatenate[_A, _P], _B]], Callable[_P, Callable[[_A], _B]]]:
     ...
 
 
 @overload
-def curry_flipped(
+def curry_flip(
     num_args: Literal[2],
 ) -> Callable[
     [Callable[Concatenate[_A, _B, _P], _C]],
@@ -143,7 +143,7 @@ def curry_flipped(
 
 
 @overload
-def curry_flipped(
+def curry_flip(
     num_args: Literal[3],
 ) -> Callable[
     [Callable[Concatenate[_A, _B, _C, _P], _D]],
@@ -162,7 +162,7 @@ def curry_flipped(
 
 
 @overload
-def curry_flipped(
+def curry_flip(
     num_args: Literal[4],
 ) -> Callable[
     [Callable[Concatenate[_A, _B, _C, _D, _P], _E]],
@@ -180,7 +180,7 @@ def curry_flipped(
     ...
 
 
-def curry_flipped(
+def curry_flip(
     num_args: _Arity,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """A flipped curry decorator.
@@ -194,7 +194,7 @@ def curry_flipped(
         function
 
     Example:
-        >>> @curry_flipped(1)
+        >>> @curry_flip(1)
         ... def map(source: List[int], mapper: Callable[[int], int]):
         ...    return [mapper(x) for x in source]
         >>>
@@ -213,4 +213,4 @@ def curry_flipped(
     return _wrap_fun
 
 
-__all__ = ["curry", "curry_flipped"]
+__all__ = ["curry", "curry_flip"]

--- a/tests/test_curried.py
+++ b/tests/test_curried.py
@@ -2,7 +2,7 @@ from typing import Callable, List
 
 import pytest
 
-from expression import curry, curry_flipped, pipe
+from expression import curry, curry_flip, pipe
 
 
 def test_curry_identity():
@@ -87,8 +87,8 @@ def test_curry1of3_with_optional2():
     assert add(3)(4, c=9) == 16
 
 
-def test_curry_flipped_identity():
-    @curry_flipped(0)
+def test_curry_flip_identity():
+    @curry_flip(0)
     def add(a: int, b: int) -> int:
         """Add a + b"""
         return a + b
@@ -96,10 +96,10 @@ def test_curry_flipped_identity():
     assert add(3, 4) == 7
 
 
-def test_curry_flipped_1():
+def test_curry_flip_1():
     xs = [1, 2, 3]
 
-    @curry_flipped(1)
+    @curry_flip(1)
     def map(source: List[int], mapper: Callable[[int], int]):
         return [mapper(x) for x in source]
 
@@ -111,10 +111,10 @@ def test_curry_flipped_1():
     assert ys == [10, 20, 30]
 
 
-def test_curry_flipped_2():
+def test_curry_flip_2():
     xs = [1, 2, 3]
 
-    @curry_flipped(2)
+    @curry_flip(2)
     def map(a: int, source: List[int], mapper: Callable[[int], int]):
         return [mapper(x) + a for x in source]
 


### PR DESCRIPTION
Rename `curry_flipped` to the shorter `curry_flip` that is also closer to the `flip` function that inspired its name.