### PR TITLE
extra feature: more typed catch

### DIFF
--- a/expression/extra/result/catch.py
+++ b/expression/extra/result/catch.py
@@ -52,7 +52,7 @@ class _Catch(Generic[ErrorT]):
         Callable[ParamT, Result[ValueT, Union[ErrorT, OtherErrorT]]],
     ]:
         if isinstance(func, _Catched):
-            return func.combine(self)
+            return func.combine(self)  # type: ignore
         return _Catched(func, catch=self)  # type: ignore
 
 

--- a/expression/extra/result/catch.py
+++ b/expression/extra/result/catch.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from inspect import signature
-from typing import Callable, Generic, ParamSpec, TypeVar, Union, overload
+from typing import Callable, Generic, ParamSpec, TypeVar, Union, final, overload
 
 from expression import Error, Ok, Result
 
@@ -12,6 +12,7 @@ OtherErrorT = TypeVar("OtherErrorT", bound=Exception)
 AnotherErrorT = TypeVar("AnotherErrorT", bound=Exception)
 
 
+@final
 class _Catch(Generic[ErrorT]):
     def __init__(self, error: Union[type[ErrorT], tuple[type[ErrorT], ...]]) -> None:
         if isinstance(error, tuple):
@@ -56,6 +57,7 @@ class _Catch(Generic[ErrorT]):
         return _Catched(func, catch=self)  # type: ignore
 
 
+@final
 class _Catched(Generic[ParamT, ValueT, ErrorT]):
     def __init__(self, func: Callable[ParamT, ValueT], catch: _Catch[ErrorT]) -> None:
         self.func = func

--- a/tests/test_catch.py
+++ b/tests/test_catch.py
@@ -79,7 +79,8 @@ def test_catch_with_effect_error():
     @catch(exception=TypeError)
     @effect.try_[int]()
     def fn(a: int) -> Generator[int, Any, int]:
-        b: int = yield from Error(ValueError("failure"))
+        error: Error[int, ValueError] = Error(ValueError("failure"))
+        b: int = yield from error
         return a + b
 
     result = fn(1)


### PR DESCRIPTION
change:
```python
from expression.extra.result import catch, origin_catch


@catch(exception=TypeError)
@catch(exception=RuntimeError)
@catch(exception=ValueError)
def test_func_new(a: int) -> int:
    return a


@origin_catch(exception=TypeError)
@origin_catch(exception=RuntimeError)
@origin_catch(exception=ValueError)
def test_func_origin(a: int) -> int:
    return a


@catch(exception=TypeError)
@catch(exception=RuntimeError)
@catch(exception=ValueError)
def test_func_new_2(error: Exception) -> None:
    raise error


@origin_catch(exception=TypeError)
@origin_catch(exception=RuntimeError)
@origin_catch(exception=ValueError)
def test_func_origin_2(error: Exception) -> None:
    raise error


test_func_new
## pylance
# (function) def test_func_new(a: int) ->
# (Ok[int, TypeError | RuntimeError | ValueError]
# | Error[int, TypeError | RuntimeError | ValueError])
#
## repr
# <Catched: (a: int) -> int, [ValueError,RuntimeError,TypeError]>


test_func_origin
## pylance
# (function) def test_func_origin(...) ->
# (Ok[int, _TError@catch | ValueError | RuntimeError | TypeError]
# | Error[int, _TError@catch | ValueError | RuntimeError | TypeError])
#
## repr
# <function __main__.test_func_origin(a: int) -> int>


test_func_new_2
## pylance
# def test_func_new_2(error: Exception) ->
# (Ok[None, TypeError | RuntimeError | ValueError]
# | Error[None, TypeError | RuntimeError | ValueError])
#
## repr
# <Catched: (error: Exception) -> None, [ValueError,RuntimeError,TypeError]>


test_func_origin_2
## pylance
# (function) def test_func_origin_2(...) ->
# (Ok[None, _TError@catch | ValueError | RuntimeError | TypeError]
# | Error[None, _TError@catch | ValueError | RuntimeError | TypeError])
#
## repr
# <function __main__.test_func_origin_2(error: Exception) -> None>


error_new = test_func_new_2(ValueError("value error test"))
## pylance
# (variable) error: Ok[None, TypeError | RuntimeError | ValueError]
# | Error[None, TypeError | RuntimeError | ValueError]
#
## repr
# expression.core.result.Error(ValueError('value error test'))


error_origin = test_func_origin_2(ValueError("value error test"))
## pylance
# (variable) error_origin: Ok[None, _TError@catch | ValueError | RuntimeError | TypeError]
# | Error[None, _TError@catch | ValueError | RuntimeError | TypeError]
#
## repr
# expression.core.result.Error(ValueError('value error test'))
```